### PR TITLE
Deprecate rw_rtc.h for new RTC integration

### DIFF
--- a/Lib/Inc/rw_rtc.h
+++ b/Lib/Inc/rw_rtc.h
@@ -1,24 +1,27 @@
-#ifndef __RW_RTC_H
-#define __RW_RTC_H
+/* Depreciated
+   New one integrated RTC function with LVGL+Touchscreen in Core/Src/rtc_manager.c */
 
-#include "stm32f1xx_hal.h"
-#include "rtc.h"
-#include "time.h"
-#include "lcd.h"
-#include "stdio.h"
-#include "string.h"
+// #ifndef __RW_RTC_H
+// #define __RW_RTC_H
 
-#define RTC_INIT_FLAG 0xFEED
-#define EDIT_BTN_PORT GPIOA
-#define EDIT_BTN_PIN GPIO_PIN_0
-#define DEC_BTN_PORT GPIOC
-#define DEC_BTN_PIN GPIO_PIN_12
+// #include "stm32f1xx_hal.h"
+// #include "rtc.h"
+// #include "time.h"
+// #include "lcd.h"
+// #include "stdio.h"
+// #include "string.h"
+
+// #define RTC_INIT_FLAG 0xFEED
+// #define EDIT_BTN_PORT GPIOA
+// #define EDIT_BTN_PIN GPIO_PIN_0
+// #define DEC_BTN_PORT GPIOC
+// #define DEC_BTN_PIN GPIO_PIN_12
 
 
-HAL_StatusTypeDef RW_RTC_SetTime(struct tm *time);
-struct tm* RW_RTC_GetTime(void);
-void RW_RTC_Init(void);
-void RW_RTC_DisplayTime(void);
-void RW_RTC_ButtonHandler(void);
+// HAL_StatusTypeDef RW_RTC_SetTime(struct tm *time);
+// struct tm* RW_RTC_GetTime(void);
+// void RW_RTC_Init(void);
+// void RW_RTC_DisplayTime(void);
+// void RW_RTC_ButtonHandler(void);
 
-#endif /* __RW_RTC_H */
+// #endif /* __RW_RTC_H */


### PR DESCRIPTION
Deprecate rw_rtc.h and integrate RTC functions with LVGL Touchscreen.